### PR TITLE
Allow exporting actions as animations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -98,7 +98,13 @@ class YABEEProperty(bpy.types.PropertyGroup):
             description="Copy texture files together with EGG",
             default=True,
             )
-    
+
+    opt_anims_from_actions = BoolProperty(
+            name="All actions as animations",
+            description="Export an animation for every Action",
+            default=False,
+            )
+
     opt_separate_anim_files = BoolProperty(
             name="Separate animation files",
             description="Write an animation data into the separate files",
@@ -143,26 +149,31 @@ class YABEEProperty(bpy.types.PropertyGroup):
         row = layout.row()
         row.operator("export.yabee_reset_defaults", icon="FILE_REFRESH", text="Reset to defaults")
         row.operator("export.yabee_help", icon="URL", text="Help")
+
         layout.row().label('Animation:')
-        row = layout.row()
-        row.template_list("UI_UL_list", "anim_collection",
-                          self.opt_anim_list, 
-                          "anim_collection", 
-                          self.opt_anim_list, 
-                          "active_index", 
-                          rows=2)
-        col = row.column(align=True)
-        col.operator("export.egg_anim_add", icon='ZOOMIN', text="")
-        col.operator("export.egg_anim_remove", icon='ZOOMOUT', text="")
-        sett = self.opt_anim_list
-        if len(sett.anim_collection):
-            p = sett.anim_collection[sett.active_index]
-            layout.row().prop(p, 'name')
-            row = layout.row(align = True)
-            row.prop(p, 'from_frame')
-            row.prop(p, 'to_frame')
-            row.prop(p, 'fps')
+        layout.row().prop(self, 'opt_anims_from_actions')
+        if not self.opt_anims_from_actions:
+            row = layout.row()
+            row.template_list("UI_UL_list", "anim_collection",
+                              self.opt_anim_list,
+                              "anim_collection",
+                              self.opt_anim_list,
+                              "active_index",
+                              rows=2)
+            col = row.column(align=True)
+            col.operator("export.egg_anim_add", icon='ZOOMIN', text="")
+            col.operator("export.egg_anim_remove", icon='ZOOMOUT', text="")
+            sett = self.opt_anim_list
+            if len(sett.anim_collection):
+                p = sett.anim_collection[sett.active_index]
+                layout.row().prop(p, 'name')
+                row = layout.row(align = True)
+                row.prop(p, 'from_frame')
+                row.prop(p, 'to_frame')
+                row.prop(p, 'fps')
+
         layout.separator()
+
         layout.row().label('Options:')
         layout.row().prop(self, 'opt_anim_only')
         layout.row().prop(self, 'opt_separate_anim_files')
@@ -357,6 +368,7 @@ class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
         sett = context.scene.yabee_settings
         errors = egg_writer.write_out(self.filepath, 
                             sett.opt_anim_list.get_anim_dict(),
+                            sett.opt_anims_from_actions,
                             sett.opt_export_uv_as_texture, 
                             sett.opt_separate_anim_files, 
                             sett.opt_anim_only,

--- a/yabee.py
+++ b/yabee.py
@@ -7,6 +7,7 @@ FILE_PATH = './exp_test/test.egg'
 #: { 'animation_name' : (start_frame, end_frame, frame_rate) }
 ANIMATIONS = {'anim1':(0,10,5), 
               }
+ANIMS_FROM_ACTIONS = False
 
 #: 'True' to interprete an image in the uv layer as the texture
 EXPORT_UV_IMAGE_AS_TEXTURE = False 
@@ -81,7 +82,7 @@ if __name__ == '__main__':
     imp.reload(io_scene_egg.yabee_libs.egg_writer)
     egg_writer = io_scene_egg.yabee_libs.egg_writer
     egg_writer.write_out(FILE_PATH, 
-                        ANIMATIONS,
+                        ANIMATIONS, ANIMS_FROM_ACTIONS,
                         EXPORT_UV_IMAGE_AS_TEXTURE, 
                         SEPARATE_ANIM_FILE, 
                         ANIM_ONLY,

--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -933,7 +933,7 @@ class AnimCollector():
     convert it to the EGG string.
     """
     
-    def __init__(self, obj_list, start_f, stop_f, framerate, name):
+    def __init__(self, obj_list, start_f, stop_f, framerate, name, action=None):
         """ @param obj_list: list or tuple of the Blender's objects
         for wich needed to collect animation data.
         @param start_f: number of the "from" frame.
@@ -970,6 +970,8 @@ class AnimCollector():
                             self.obj_anim_ref[obj.yabee_name] = {}
                         self.obj_anim_ref[obj.yabee_name]['morph'] = self.collect_morph_anims(obj)
                 elif obj.type == 'ARMATURE':
+                    if action and obj.animation_data:
+                        obj.animation_data.action = action
                     self.bone_groups[obj.yabee_name] = EGGAnimJoint(None)
                     self.bone_groups[obj.yabee_name].make_hierarchy_from_list(obj.data.bones)
                     if obj.yabee_name not in list(self.obj_anim_ref.keys()):
@@ -1329,10 +1331,10 @@ def generate_shadow_uvs():
 #-----------------------------------------------------------------------
 #                           WRITE OUT                                   
 #-----------------------------------------------------------------------
-def write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex, 
-              t_path, tbs, tex_processor, b_layers, 
+def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
+              copy_tex, t_path, tbs, tex_processor, b_layers,
               m_actor, apply_m, pview, objects=None):
-    global FILE_PATH, ANIMATIONS, EXPORT_UV_IMAGE_AS_TEXTURE, \
+    global FILE_PATH, ANIMATIONS, ANIMS_FROM_ACTIONS, EXPORT_UV_IMAGE_AS_TEXTURE, \
            COPY_TEX_FILES, TEX_PATH, SEPARATE_ANIM_FILE, ANIM_ONLY, \
            STRF, CALC_TBS, TEXTURE_PROCESSOR, BAKE_LAYERS, \
            MERGE_ACTOR_MESH, APPLY_MOD, PVIEW, USED_MATERIALS, USED_TEXTURES
@@ -1342,6 +1344,7 @@ def write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
     # === prepare to write ===
     FILE_PATH = fname
     ANIMATIONS = anims
+    ANIMS_FROM_ACTIONS = from_actions
     EXPORT_UV_IMAGE_AS_TEXTURE = uv_img_as_tex
     SEPARATE_ANIM_FILE = sep_anim
     ANIM_ONLY = a_only
@@ -1451,21 +1454,34 @@ def write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
                 materials_str, USED_MATERIALS, USED_TEXTURES = get_egg_materials_str(selected_obj)
                 file.write(materials_str)
                 file.write(gr.get_full_egg_str())
+
+            anim_collectors = []
+            if ANIMS_FROM_ACTIONS:
+                # Export an animation for each action.
+                fps = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base
+
+                for action in bpy.data.actions:
+                    frange = action.frame_range
+                    ac = AnimCollector(obj_list, int(frange[0]), int(frange[1]),
+                                       fps, action.name, action)
+                    anim_collectors.append(ac)
+            else:
+                # Export animations named in ANIMATIONS dictionary.
+                for a_name, frames in ANIMATIONS.items():
+                    ac = AnimCollector(obj_list, frames[0], frames[1],
+                                       frames[2], a_name)
+                    anim_collectors.append(ac)
+
             fpa = []
-            for a_name, frames in ANIMATIONS.items():
-                ac = AnimCollector(obj_list, 
-                                    frames[0], 
-                                    frames[1], 
-                                    frames[2], 
-                                    a_name)
+            for ac in anim_collectors:
                 if not SEPARATE_ANIM_FILE:
                     file.write(ac.get_full_egg_str())
                 else:
                     a_path = FILE_PATH
                     if a_path[-4:].upper() == '.EGG':
-                        a_path = a_path[:-4] + '-' + a_name + a_path[-4:]
+                        a_path = a_path[:-4] + '-' + ac.name + a_path[-4:]
                     else:
-                        a_path = a_path + '-' + a_name + '.egg'
+                        a_path = a_path + '-' + ac.name + '.egg'
                     a_egg_str = ac.get_full_egg_str()
                     if len(a_egg_str) > 0:
                         a_file = open(a_path, 'w')
@@ -1473,8 +1489,10 @@ def write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
                         a_file.write(ac.get_full_egg_str())
                         a_file.close()
                         fpa.append(a_path)
+
             if ((not ANIM_ONLY) or (not SEPARATE_ANIM_FILE)):
                 file.close()
+
             if CALC_TBS == 'PANDA':
                 try:
                     fp = os.path.abspath(FILE_PATH)
@@ -1485,7 +1503,7 @@ def write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
             if PVIEW:
                 try:
                     fp = os.path.abspath(FILE_PATH)
-                    subprocess.Popen(['pview', fp] + fpa)
+                    subprocess.Popen(['pview', '-i', fp] + fpa)
                 except:
                     print('ERROR: Can\'t execute pview')
     except Exception as exc:


### PR DESCRIPTION
I have a model that is already animated, and has all the animations as individual Action objects (this is the way that you have multiple animations when working with the BGE, too).  To export each one of them, YABEE currently requires me to select one, go to the exporter, set the frame range, export, select the next, go to the exporter, etc, etc.  And I need to do that every time I want to re-export all the animations, which is extremely tedious.

This patch adds an "Animations from actions" option that, instead of taking the animations from a list, just exports one animation for each action.  This seems like the better way to do it in general, to be honest.  Disadvantages are that you can't specify a per-animation frame range or FPS, but that can be worked around, or added in the GUI in the future.

Sorry that this patch is a bit rudimentary, there could probably be more options for this... I guess it could be a useful starting point for now.  There are more improvements I'd like to see in YABEE's animation handling but this is all I have time for right now. :-) 

You may notice the -i option I'm passing to pview; it means that it will also try to match up animations that don't have a <Bundle> name corresponding to a character name.  This allows previewing all of the animations in pview; you can use "a" to toggle through the animations in pview.  (But pview has a bug here: if I switch to a different animation using "a", it won't actually update the animation unless I hit the "play" button again.  I'll try to fix that.)