### PR TITLE
Use %f explicitly for <UV> to emit float instead of double

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -624,7 +624,7 @@ class EGGMeshObjectData(EGGBaseObjectData):
             tbs = ''
             if self.tangent_layers:
                 tbs = '\n    <Tangent> {%f %f %f}\n    <Binormal> {%f %f %f}' % self.tangent_layers[i][ividx]
-            uv_str = '  <UV> %s {\n    %s %s %s\n  }' % (name, data[ividx][0], data[ividx][1], tbs)
+            uv_str = '  <UV> %s {\n    %f %f %s\n  }' % (name, data[ividx][0], data[ividx][1], tbs)
             attributes.append(uv_str)
 
         return attributes


### PR DESCRIPTION
I noticed some .eggs are larger than necessary.  Using %f instead of %s emits the float- instead of double-precision UV coordinate.  Only a texture of size 2^23 pixels on a side would need the double precision :)