### PR TITLE
Make external .egg references possible by adding a File tag to an Empty

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -172,6 +172,9 @@ class Group:
                 elif normalized in ('collide-mask', 'from-collide-mask', 'into-collide-mask', 'bin', 'draw-order'):
                     vals = ('  ' * level, prop.name, prop.value)
                     egg_str += '%s<Scalar> %s { %s }\n' % vals
+                elif normalized == 'file' and self.object.type == 'EMPTY':
+                    vals = ('  ' * level, prop.value)
+                    egg_str += '%s<Instance> { <File> { %s } }\n' % vals
                 else:
                     vals = ('  ' * level, eggSafeName(prop.name), eggSafeName(prop.value))
                     egg_str += '%s<Tag> %s { %s }\n' % vals


### PR DESCRIPTION
This is a feature that was in Chicken and was really useful for using Blender as scene editor, especially in combination with DupliGroups.

If you want to instantiate an external object, a really great way to do that in Blender is to create an Empty, link with the other .blend file, and then set that Empty to duplicate a group from that other .blend file.

This allows it to retain its usefulness when exporting to .egg.  You can now give an Empty a "file" property and set it to "myobject.egg" and YABEE will write out a &lt;File&gt; { myobject.egg } reference inside an &lt;Instance&gt; tag (the latter is necessary to create the myobject.egg in local coordinates instead of in global coordinates).

This way of editing scenes is great because you don't end up with bloated scene .egg files.