### PR TITLE
Fix trailing whitespaces + PBS Export

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ class EGGBakeProperty(bpy.types.PropertyGroup):
     res_x = IntProperty(name = "Res. X", default=512)
     res_y = IntProperty(name = "Res. Y", default=512)
     export = BoolProperty(default = False)
-    
+
     def draw(self, row, name):
         row.prop(self, "res_x")
         row.prop(self, "res_y")
@@ -39,17 +39,17 @@ class EGGAnimationProperty(bpy.types.PropertyGroup):
     from_frame = IntProperty(name="From", default=1)
     to_frame = IntProperty(name="To", default=2)
     fps = IntProperty(name="FPS", default=24)
-    
+
     def __get_idx(self):
         return list(bpy.context.scene.yabee_settings.opt_anim_list.anim_collection).index(self)
-        
+
     index = property(__get_idx)
 
 class EGGAnimList(bpy.types.PropertyGroup):
     ''' Animations list settings '''
     active_index = IntProperty()
     anim_collection = CollectionProperty(type=EGGAnimationProperty)
-    
+
     def get_anim_dict(self):
         d = {}
         for anim in self.anim_collection:
@@ -67,15 +67,15 @@ class YABEEProperty(bpy.types.PropertyGroup):
                    ('RAW', "Raw", "Raw textures for using with Blender shaders.")),
             default='SIMPLE',
             )
-            
+
     opt_bake_diffuse = PointerProperty(type=EGGBakeProperty)
     opt_bake_normal = PointerProperty(type=EGGBakeProperty)
     opt_bake_gloss = PointerProperty(type=EGGBakeProperty)
     opt_bake_glow = PointerProperty(type=EGGBakeProperty)
     opt_bake_AO = PointerProperty(type=EGGBakeProperty)
     opt_bake_shadow = PointerProperty(type=EGGBakeProperty)
-    
-            
+
+
     opt_tbs_proc = EnumProperty(
             name="TBS generation",
             description="Export all textures as MODULATE or bake texture layers",
@@ -85,14 +85,14 @@ class YABEEProperty(bpy.types.PropertyGroup):
                    ('NO', "No", "Do not generate TBS.")),
             default='NO',
             )
-            
+
 
     opt_export_uv_as_texture = BoolProperty(
             name="UV as texture",
             description="export uv image as texture",
             default=False,
             )
-    
+
     opt_copy_tex_files = BoolProperty(
             name="Copy texture files",
             description="Copy texture files together with EGG",
@@ -122,29 +122,29 @@ class YABEEProperty(bpy.types.PropertyGroup):
             description="Path for the copied textures. Relative to the main EGG file dir",
             default='./tex',
             )
-            
+
     opt_merge_actor = BoolProperty(
             name="Merge actor",
             description="Merge meshes, armatured by single Armature",
             default=False,
             )
-            
+
     opt_apply_modifiers = BoolProperty(
             name="Apply modifiers",
             description="Apply modifiers on exported objects (except Armature)",
             default=True,
             )
-            
+
     opt_pview = BoolProperty(
             name="Pview",
             description="Run pview after exporting",
             default=False,
             )
-            
+
     opt_anim_list = PointerProperty(type=EGGAnimList)
-    
+
     first_run = BoolProperty(default = True)
-    
+
     def draw(self, layout):
         row = layout.row()
         row.operator("export.yabee_reset_defaults", icon="FILE_REFRESH", text="Reset to defaults")
@@ -203,7 +203,7 @@ class YABEEProperty(bpy.types.PropertyGroup):
             layout.row().prop(self, 'opt_merge_actor')
             layout.row().prop(self, 'opt_apply_modifiers')
             layout.row().prop(self, 'opt_pview')
-    
+
     def get_bake_dict(self):
         d = {}
         opts = ((self.opt_bake_diffuse, 'diffuse'),
@@ -222,7 +222,7 @@ class YABEEProperty(bpy.types.PropertyGroup):
             else:
                 d[name] = (opt.res_x, opt.res_y, opt.export)
         return d
-    
+
     def check_warns(self, context):
         warns = []
         if len(context.selected_objects) == 0:
@@ -235,10 +235,10 @@ class YABEEProperty(bpy.types.PropertyGroup):
                              'It means that in this case your animation contains\n' + \
                              'zero of frames. YABEE will automatically add one frame\n' + \
                              'to the "to" value of "%s" animation.') % (name, name))
-        
+
         return warns
-        
-    def reset_defaults(self):        
+
+    def reset_defaults(self):
         self.opt_tex_proc = 'SIMPLE'
         self.opt_tbs_proc = 'NO'
         self.opt_bake_diffuse.export = True
@@ -264,7 +264,7 @@ class YABEEProperty(bpy.types.PropertyGroup):
         while self.opt_anim_list.anim_collection[:]:
             bpy.ops.export.egg_anim_remove('INVOKE_DEFAULT')
         self.first_run = False
-    
+
 
 #def write_some_data(context, filepath, use_some_setting):
 #    print("running write_some_data...")
@@ -279,12 +279,12 @@ class YABEEProperty(bpy.types.PropertyGroup):
 class YABEEHelp(bpy.types.Operator):
     bl_idname = "export.yabee_help"
     bl_label = "YABEE Help."
-    
+
     def execute(self, context):
         bpy.ops.wm.url_open("INVOKE_DEFAULT", url="http://www.panda3d.org/forums/viewtopic.php?t=11441")
         return {"FINISHED"}
-    
-    
+
+
 class WarnDialog(bpy.types.Operator):
     ''' Warning messages operator '''
     bl_idname = "export.yabee_warnings"
@@ -305,14 +305,14 @@ class WarnDialog(bpy.types.Operator):
 
     def invoke(self, context, event):
         wm = context.window_manager
-        return wm.invoke_props_dialog(self) 
+        return wm.invoke_props_dialog(self)
 
 
 class ResetDefault(bpy.types.Operator):
     ''' Reset YABEE settings to default operator '''
     bl_idname = "export.yabee_reset_defaults"
     bl_label = "YABEE reset default settings"
-    
+
     def execute(self, context):
         context.scene.yabee_settings.reset_defaults()
         return {'FINISHED'}
@@ -322,7 +322,7 @@ class AddAnim(bpy.types.Operator):
     ''' Add animation record operator '''
     bl_idname = "export.egg_anim_add"
     bl_label = "Add EGG animation"
-    
+
     def execute(self, context):
         prop = context.scene.yabee_settings.opt_anim_list.anim_collection.add()
         prop.name = 'Anim'+str(prop.index)
@@ -333,7 +333,7 @@ class RemoveAnim(bpy.types.Operator):
     ''' Remove active animation record operator '''
     bl_idname = "export.egg_anim_remove"
     bl_label = "Remove EGG animation"
-    
+
     def execute(self, context):
         sett = context.scene.yabee_settings.opt_anim_list
         sett.anim_collection.remove(sett.active_index)
@@ -346,7 +346,7 @@ class RemoveAnim(bpy.types.Operator):
 
 class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
     ''' Export selected to the Panda3D EGG format '''
-    bl_idname = "export.panda3d_egg"  
+    bl_idname = "export.panda3d_egg"
     bl_label = "Export to Panda3D EGG"
 
     # ExportHelper mixin class uses this
@@ -357,7 +357,7 @@ class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
             options={'HIDDEN'},
             )
 
-    #@classmethod       
+    #@classmethod
     #def poll(cls, context):
     #    #return context.active_object is not None
     #    return len(context.selected_objects) > 0
@@ -366,14 +366,14 @@ class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
         import imp
         imp.reload(egg_writer)
         sett = context.scene.yabee_settings
-        errors = egg_writer.write_out(self.filepath, 
+        errors = egg_writer.write_out(self.filepath,
                             sett.opt_anim_list.get_anim_dict(),
                             sett.opt_anims_from_actions,
-                            sett.opt_export_uv_as_texture, 
-                            sett.opt_separate_anim_files, 
+                            sett.opt_export_uv_as_texture,
+                            sett.opt_separate_anim_files,
                             sett.opt_anim_only,
-                            sett.opt_copy_tex_files, 
-                            sett.opt_tex_path, 
+                            sett.opt_copy_tex_files,
+                            sett.opt_tex_path,
                             sett.opt_tbs_proc,
                             sett.opt_tex_proc,
                             sett.get_bake_dict(),
@@ -392,19 +392,19 @@ class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
                 rep_msg += 'Unexpected error while creating object. See console for traceback.'
             self.report({'ERROR'}, rep_msg)
             return {'CANCELLED'}
-        
-        
+
+
     def invoke(self, context, evt):
         if context.scene.yabee_settings.first_run:
             context.scene.yabee_settings.reset_defaults()
         return ExportHelper.invoke(self, context, evt)
-        
+
     def draw(self, context):
         warns = context.scene.yabee_settings.check_warns(context)
         if warns:
             self.layout.row().operator('export.yabee_warnings', icon='ERROR', text='Warning!')
         context.scene.yabee_settings.draw(self.layout)
-        
+
 
 
 def menu_func_export(self, context):
@@ -416,7 +416,7 @@ def register():
 
     # Good or bad, but I'll store settings in the scene
     bpy.types.Scene.yabee_settings = PointerProperty(type=YABEEProperty)
-    # Hack again. I use custom property to be able to get basic 
+    # Hack again. I use custom property to be able to get basic
     # object name in the copy of the scene.
     bpy.types.Object.yabee_name = StringProperty(name="YABEE_Name", default="Unknown")
     bpy.types.Mesh.yabee_name = StringProperty(name="YABEE_Name", default="Unknown")

--- a/__init__.py
+++ b/__init__.py
@@ -141,6 +141,12 @@ class YABEEProperty(bpy.types.PropertyGroup):
             default=False,
             )
 
+    opt_export_pbs = BoolProperty(
+            name="Export PBS",
+            description="Export Physically Based Properties, requires the BAM Exporter",
+            default=False
+        )
+
     opt_anim_list = PointerProperty(type=EGGAnimList)
 
     first_run = BoolProperty(default = True)
@@ -204,6 +210,8 @@ class YABEEProperty(bpy.types.PropertyGroup):
             layout.row().prop(self, 'opt_apply_modifiers')
             layout.row().prop(self, 'opt_pview')
 
+            layout.row().prop(self, 'opt_export_pbs')
+
     def get_bake_dict(self):
         d = {}
         opts = ((self.opt_bake_diffuse, 'diffuse'),
@@ -261,6 +269,7 @@ class YABEEProperty(bpy.types.PropertyGroup):
         self.opt_merge_actor = True
         self.opt_apply_modifiers = True
         self.opt_pview = False
+        self.opt_export_pbs = False
         while self.opt_anim_list.anim_collection[:]:
             bpy.ops.export.egg_anim_remove('INVOKE_DEFAULT')
         self.first_run = False
@@ -379,7 +388,8 @@ class ExportPanda3DEGG(bpy.types.Operator, ExportHelper):
                             sett.get_bake_dict(),
                             sett.opt_merge_actor,
                             sett.opt_apply_modifiers,
-                            sett.opt_pview)
+                            sett.opt_pview,
+                            sett.opt_export_pbs)
         if not errors:
             return {'FINISHED'}
         else:

--- a/yabee.py
+++ b/yabee.py
@@ -2,22 +2,22 @@
 """
 # -------------- Change this to setup parameters -----------------------
 #: file name to write
-FILE_PATH = './exp_test/test.egg' 
+FILE_PATH = './exp_test/test.egg'
 
 #: { 'animation_name' : (start_frame, end_frame, frame_rate) }
-ANIMATIONS = {'anim1':(0,10,5), 
+ANIMATIONS = {'anim1':(0,10,5),
               }
 ANIMS_FROM_ACTIONS = False
 
 #: 'True' to interprete an image in the uv layer as the texture
-EXPORT_UV_IMAGE_AS_TEXTURE = False 
+EXPORT_UV_IMAGE_AS_TEXTURE = False
 
 #: 'True' to copy texture images together with main.egg
 COPY_TEX_FILES = True
 
 #: Path for the copied textures. Relative to the main EGG file dir.
 #: For example if main file path is '/home/username/test/test.egg',
-#: texture path is './tex', then the actual texture path is 
+#: texture path is './tex', then the actual texture path is
 #: '/home/username/test/tex'
 TEX_PATH = './tex'
 
@@ -30,7 +30,7 @@ ANIM_ONLY = False
 #: number of sign after point
 FLOATING_POINT_ACCURACY = 3
 
-#: Enable tangent space calculation. Tangent space needed for some 
+#: Enable tangent space calculation. Tangent space needed for some
 # shaders/autoshaders, but increase exporting time
 # 'NO', 'INTERNAL', 'PANDA'
 # 'INTERNAL' - use internal TBS calculation
@@ -39,13 +39,13 @@ FLOATING_POINT_ACCURACY = 3
 CALC_TBS = 'PANDA'
 
 #: Type of texture processing. May be 'SIMPLE' or 'BAKE'.
-# 'SIMPLE' - export all texture layers as MODULATE. 
-# Exceptions: 
+# 'SIMPLE' - export all texture layers as MODULATE.
+# Exceptions:
 #   use map normal == NORMAL
 #   use map specular == GLOSS
 #   use map emit == GLOW
 # 'BAKE' - bake textures. BAKE_LAYERS setting up what will be baked.
-# Also diffuse color of the material would set to (1,1,1) in the 
+# Also diffuse color of the material would set to (1,1,1) in the
 # 'BAKE' mode
 TEXTURE_PROCESSOR = 'BAKE'
 #TEXTURE_PROCESSOR = 'SIMPLE'
@@ -74,20 +74,20 @@ if __name__ == '__main__':
                 sys.path.append(os.path.abspath(dir))
     except:
         print('Error while trying to add a paths in the sys.path')
-        
+
     import io_scene_egg.yabee_libs.egg_writer
     #from io_scene_egg.yabee_libs import egg_writer
     print('RELOADING MODULES')
     import imp
     imp.reload(io_scene_egg.yabee_libs.egg_writer)
     egg_writer = io_scene_egg.yabee_libs.egg_writer
-    egg_writer.write_out(FILE_PATH, 
+    egg_writer.write_out(FILE_PATH,
                         ANIMATIONS, ANIMS_FROM_ACTIONS,
-                        EXPORT_UV_IMAGE_AS_TEXTURE, 
-                        SEPARATE_ANIM_FILE, 
+                        EXPORT_UV_IMAGE_AS_TEXTURE,
+                        SEPARATE_ANIM_FILE,
                         ANIM_ONLY,
-                        COPY_TEX_FILES, 
-                        TEX_PATH, 
+                        COPY_TEX_FILES,
+                        TEX_PATH,
                         FLOATING_POINT_ACCURACY,
                         CALC_TBS,
                         TEXTURE_PROCESSOR,

--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -63,7 +63,7 @@ class Group:
                 pass
             else:
                 self._yabee_object = EGGBaseObjectData(self.object)
-    
+
     def update_joints_data(self, actor_data_list = None):
         if actor_data_list == None:
             actor_data_list = []
@@ -78,7 +78,7 @@ class Group:
             self._yabee_object = EGGJointObjectData(self.object, vref, self.arm_owner)
         for ch in self.children:
             ch.update_joints_data(actor_data_list)
-    
+
     def check_parenting(self, p, o, obj_list):
         # 0 - Not
         # 1 - Object to object
@@ -94,19 +94,19 @@ class Group:
         if p and p.__class__ == bpy.types.Bone \
            and o.__class__ == bpy.types.Bone and o.parent == p:
             return 2
-        # ACHTUNG!!! Be careful: If we have two armatures with the 
-        # same bones name and object, attached to it, 
+        # ACHTUNG!!! Be careful: If we have two armatures with the
+        # same bones name and object, attached to it,
         # then we can get unexpected results!
         if o.__class__ != bpy.types.Bone and o.parent_type == 'BONE' \
            and p and o.parent_bone == p.name:
             return 3
         return 0
-    
+
     def make_hierarchy_from_list(self, obj_list):
         """ This function make <Group> hierarchy from the list of
-        Blender's objects. Self.object is the top level of the created 
+        Blender's objects. Self.object is the top level of the created
         hierarchy. Usually in this case self.object == None
-        
+
         @param obj_list: tuple or lis of blender's objects.
         """
         try:
@@ -143,22 +143,22 @@ class Group:
             print_exc()
             return ['ERR_MK_HIERARCHY',]
         return []
-                
+
     def print_hierarchy(self, level = 0):
         """ Debug function to print out hierarchy to console.
-        
+
         @param level: starting indent level.
         """
         print('-' * level, self.object)
         for ch in self.children:
             ch.print_hierarchy(level+1)
-            
+
     def get_tags_egg_str(self, level = 0):
-        """ Create and return <Tag> string from Blender's object 
+        """ Create and return <Tag> string from Blender's object
         Game logic properties.
-        
+
         @param level: indent level.
-        
+
         @return: the EGG tags string.
         """
         egg_str = ''
@@ -179,17 +179,17 @@ class Group:
                     vals = ('  ' * level, eggSafeName(prop.name), eggSafeName(prop.value))
                     egg_str += '%s<Tag> %s { %s }\n' % vals
         return egg_str
-                
+
     def get_full_egg_str(self, level = 0):
         return ''.join(self.get_full_egg_str_arr(level))
-    
+
     def get_full_egg_str_arr(self,level = 0):
-        """ Create and return representation of the EGG  <Group>  
+        """ Create and return representation of the EGG  <Group>
         with hierarchy, started from self.object. It's start point to
         generating EGG structure.
-        
+
         @param level: starting indent level.
-        
+
         @return: full EGG string of group.
         """
         egg_str = []
@@ -216,21 +216,21 @@ class Group:
             for ch in self.children:
                 egg_str.append( ch.get_full_egg_str(level + 1) )
         return egg_str
-                    
+
 
 class EGGArmature(Group):
-    """ Representation of the EGG <Joint> hierarchy. Recive Blender's 
+    """ Representation of the EGG <Joint> hierarchy. Recive Blender's
     bones list as obj_list in constructor.
     """
-    
+
     def get_full_egg_str(self, vrefs, arm_owner, level = 0):
-        """ Create and return string representation of the EGG <Joint> 
+        """ Create and return string representation of the EGG <Joint>
         with hierachy.
-        
+
         @param vrefs: reference of vertices, linked to bones.
         @param arm_owner: Armature object - owner of the bones
         @param level: indent level.
-        
+
         @return: the EGG string with joints hierarchy
         """
         egg_str = ''
@@ -257,19 +257,19 @@ class EGGArmature(Group):
 
 
 #-----------------------------------------------------------------------
-#                           BASE OBJECT                                 
+#                           BASE OBJECT
 #-----------------------------------------------------------------------
 class EGGBaseObjectData:
     """ Base representation of the EGG objects  data
     """
-    
+
     def __init__(self, obj):
         self.obj_ref = obj
         if obj.parent:
             self.transform_matrix = obj.matrix_local
         else:
             self.transform_matrix = obj.matrix_world
-        
+
     def get_transform_str(self):
         """ Return the EGG string representation of object transforms.
         """
@@ -282,10 +282,10 @@ class EGGBaseObjectData:
             tr_str.append('\n')
         tr_str.append( '  }\n}\n' )
         return ''.join(tr_str)
-        
+
     def get_full_egg_str(self):
         return self.get_transform_str() + '\n'
-        
+
 
 class EGGNurbsCurveObjectData(EGGBaseObjectData):
     """ Representation of the EGG NURBS Curve
@@ -297,14 +297,14 @@ class EGGNurbsCurveObjectData(EGGBaseObjectData):
             for vtx in spline.points:
                 co = self.obj_ref.matrix_world * vtx.co
                 fixed_co = tuple(map(lambda x: x * co[3], co[:3])) + (co[3],)
-                vertices.append('<Vertex> %i {\n  %s\n}\n' % (idx, 
+                vertices.append('<Vertex> %i {\n  %s\n}\n' % (idx,
                                     ' '.join(map(STRF, fixed_co))))
                 idx += 1
         return vertices
-                
-        
+
+
     def get_vtx_pool_str(self):
-        """ Return the vertex pool string in the EGG syntax. 
+        """ Return the vertex pool string in the EGG syntax.
         """
         vtx_pool = ''
         vertices = self.collect_vertices()
@@ -316,10 +316,10 @@ class EGGNurbsCurveObjectData(EGGBaseObjectData):
             vtx_pool += '}\n'
             #vtx_pool = '<VertexPool> %s {\n %s}\n' % (eggSafeName(self.obj_ref.yabee_name), '\n  '.join(vertices))
         return vtx_pool
-        
+
     def get_curves_str(self):
         """ Return the <NURBSCurve> string. Blender 2.5 has not contain
-        Knots information, seems it's calculating in runtime. 
+        Knots information, seems it's calculating in runtime.
         I got algorythm for the knots calculation from the OBJ exporter
         and modified it.
         """
@@ -341,21 +341,21 @@ class EGGNurbsCurveObjectData(EGGBaseObjectData):
                                                     (spline.point_count_u - 1))
                 cur_str += '  <Order> { %i }\n' % spline.order_u
                 cur_str += '  <Knots> { %s }\n' % ' '.join(map(str2f, knots))
-                cur_str += '  <VertexRef> {\n    %s\n    <Ref> { %s } \n  }\n' % ( 
+                cur_str += '  <VertexRef> {\n    %s\n    <Ref> { %s } \n  }\n' % (
                         ' '.join([str(i) for i in range(idx, idx + \
                         spline.point_count_u)]), eggSafeName(self.obj_ref.yabee_name))
                 cur_str += '}\n'
                 idx += spline.point_count_u
         return cur_str
-        
+
     def get_full_egg_str(self):
         return self.get_transform_str() + self.get_vtx_pool_str() + self.get_curves_str()
-        
+
 
 class EGGJointObjectData(EGGBaseObjectData):
     """ Representation of the EGG <Joint> data
     """
-    
+
     def __init__(self, obj, vref, arm_owner):
         """ @param vref: reference of vertices, linked to bone.
         @param arm_owner: Armature object - owner of the bone
@@ -367,7 +367,7 @@ class EGGJointObjectData(EGGBaseObjectData):
         else:
             self.transform_matrix = obj.parent.matrix_local.inverted() * obj.matrix_local
         self.vref = vref
-        
+
     def get_vref_str(self):
         """ Convert vertex reference to the EGG string and return it.
         """
@@ -388,7 +388,7 @@ class EGGJointObjectData(EGGBaseObjectData):
                     vref_str += '  <Scalar> membership { %s }' % wgrp
                     vref_str += '  <Ref> { %s }\n}\n' % vpool
         return vref_str
-    
+
     def get_full_egg_str(self):
         egg_str = ''
         egg_str += self.get_transform_str()
@@ -405,10 +405,10 @@ class EGGJointObjectData(EGGBaseObjectData):
                 egg_str += line + '\n'
         '''
         return  egg_str
-        
-        
+
+
 #-----------------------------------------------------------------------
-#                           MESH OBJECT                                 
+#                           MESH OBJECT
 #-----------------------------------------------------------------------
 class EGGMeshObjectData(EGGBaseObjectData):
     """ EGG data representation of the mesh object
@@ -437,7 +437,7 @@ class EGGMeshObjectData(EGGBaseObjectData):
                     break
         if need_orco:
             self.pre_calc_ORCO()
-        
+
         # Store current active UV name
         self.active_uv = None
         auv = [uv for uv in obj.data.uv_textures if uv.active]
@@ -446,11 +446,11 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
 
     #-------------------------------------------------------------------
-    #                           AUXILIARY                               
+    #                           AUXILIARY
 
     def get_smooth_vtx_list(self):
-        """ Collect the smoothed polygon vertices 
-        for write normals of the vertices. In the EGG for the smooth 
+        """ Collect the smoothed polygon vertices
+        for write normals of the vertices. In the EGG for the smooth
         shading used normals of vertices. For solid - polygons.
         """
         vtx_list = []
@@ -471,10 +471,10 @@ class EGGMeshObjectData(EGGBaseObjectData):
                             if iv in vtx_list:
                                 vtx_list.remove(iv)
         return vtx_list
-        
+
     def pre_convert_uvs(self):
-        """ Blender uses shared vertices, but for the correct working 
-        UV and shading in the Panda needs to convert they are in the 
+        """ Blender uses shared vertices, but for the correct working
+        UV and shading in the Panda needs to convert they are in the
         individual vertices for each polygon.
         """
         uv_list = []
@@ -485,10 +485,10 @@ class EGGMeshObjectData(EGGBaseObjectData):
                 data.append((u,v))
             uv_list.append((uv_layer.name, data))
         return uv_list
-        
+
     def pre_convert_poly_vtx_ref(self):
-        """ Blender uses shared vertices, but for the correct working 
-        UV and shading in the Panda needs to convert they are in the 
+        """ Blender uses shared vertices, but for the correct working
+        UV and shading in the Panda needs to convert they are in the
         individual vertices for each polygon.
         """
         poly_vtx_ref = []
@@ -500,7 +500,7 @@ class EGGMeshObjectData(EGGBaseObjectData):
                 idx += 1
             poly_vtx_ref.append(vtxs)
         return poly_vtx_ref
-        
+
     def pre_convert_vtx_color(self):
         color_vtx_ref = []
         if self.obj_ref.data.vertex_colors.active:
@@ -512,9 +512,9 @@ class EGGMeshObjectData(EGGBaseObjectData):
             #    for vi, v in enumerate(face.vertices):
             #        color_vtx_ref.append(col[vi])
         return color_vtx_ref
-    
+
     def pre_calc_TBS(self):
-        """ Use Blender internal algorythm to generate tangent and 
+        """ Use Blender internal algorythm to generate tangent and
         bitangent (binormal) for each UV layer
         """
         tangent_layers = []
@@ -559,26 +559,26 @@ class EGGMeshObjectData(EGGBaseObjectData):
         self.uvs_list.append(('ORCO', data))
 
     #-------------------------------------------------------------------
-    #                           VERTICES                                
+    #                           VERTICES
 
     def collect_vtx_xyz(self, vidx, attributes):
         """ Add coordinates of the vertex to the vertex attriibutes list
-        
+
         @param vidx: Blender's internal vertex index.
         @param attributes: list of vertex attributes
-        
+
         @return: list of vertex attributes.
         """
         co = self.obj_ref.matrix_world * self.obj_ref.data.vertices[vidx].co
         attributes.append('%f %f %f' % co[:])
         return attributes
-        
+
     def collect_vtx_dxyz(self, vidx, attributes):
         """ Add morph target <Dxyz> to the vertex attributes list.
-        
+
         @param vidx: Blender's internal vertex index.
         @param attributes: list of vertex attributes
-        
+
         @return: list of vertex attributes.
         """
         if ((self.obj_ref.data.shape_keys) and (len(self.obj_ref.data.shape_keys.key_blocks) > 1)):
@@ -591,14 +591,14 @@ class EGGMeshObjectData(EGGBaseObjectData):
                     attributes.append('<Dxyz> %s { %f %f %f }\n' % \
                                       (eggSafeName(key.name), co[0], co[1], co[2]))
         return attributes
-        
+
     def collect_vtx_normal(self, v, idx, attributes):
         """ Add <Normal> to the vertex attributes list.
-        
+
         @param v: Blender vertex index.
         @param idx: the EGG (converted) vertex index.
         @param attributes: list of vertex attributes
-        
+
         @return: list of vertex attributes.
         """
         if idx in self.smooth_vtx_list:
@@ -620,11 +620,11 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
     def collect_vtx_uv(self, vidx, ividx, attributes):
         """ Add <UV> to the vertex attributes list.
-        
+
         @param vidx: the EGG (converted) vertex index.
         @param ividx: Blender internal vertex index.
         @param attributes: list of vertex attributes
-        
+
         @return: list of vertex attributes.
         """
         for uv in self.uvs_list:
@@ -637,16 +637,16 @@ class EGGMeshObjectData(EGGBaseObjectData):
             attributes.append(uv_str)
 
         return attributes
-        
+
     def collect_vertices(self):
-        """ Convert and collect vertices info. 
+        """ Convert and collect vertices info.
         """
         xyz = self.collect_vtx_xyz
         dxyz = self.collect_vtx_dxyz
         normal = self.collect_vtx_normal
         rgba = self.collect_vtx_rgba
         uv = self.collect_vtx_uv
-        
+
         vertices = []
         idx = 0
         for f in self.obj_ref.data.polygons:
@@ -665,18 +665,18 @@ class EGGMeshObjectData(EGGBaseObjectData):
                 idx += 1
         return vertices
 
-        
 
-    
+
+
     #-------------------------------------------------------------------
-    #                           POLYGONS                                
-    
+    #                           POLYGONS
+
     def collect_poly_tref(self, face, attributes):
         """ Add <TRef> to the polygon's attributes list.
-        
+
         @param face: face index.
         @param attributes: list of polygon's attributes.
-        
+
         @return: list of polygon's attributes.
         """
         global USED_TEXTURES, TEXTURE_PROCESSOR
@@ -727,10 +727,10 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
                 # Material has no per-face textures enabled
                 else:
-                    
+
                     # Look up original texture name before it was copied/renamed
                     orig_tex_names = material.yabee_texture_slots.split(NAME_SEPARATOR)
-                    
+
                     # Just store all texture slots
                     for index, texture in enumerate(material.texture_slots):
 
@@ -751,7 +751,7 @@ class EGGMeshObjectData(EGGBaseObjectData):
             for tex_name in textures:
                 if tex_name in USED_TEXTURES: # Make sure that  we'll have this texture in header
                     attributes.append('<TRef> { %s }' % eggSafeName(tex_name))
-        
+
         else:
             if self.obj_ref.data.uv_textures:
                 for btype, params in BAKE_LAYERS.items():
@@ -763,13 +763,13 @@ class EGGMeshObjectData(EGGBaseObjectData):
                                     + '_' + btype))
 
         return attributes
-    
+
     def collect_poly_mref(self, face, attributes):
         """ Add <MRef> to the polygon's attributes list.
-        
+
         @param face: face index.
         @param attributes: list of polygon's attributes.
-        
+
         @return: list of polygon's attributes.
         """
         if face.material_index < len(self.obj_ref.data.materials):
@@ -778,13 +778,13 @@ class EGGMeshObjectData(EGGBaseObjectData):
                 return attributes
             attributes.append('<MRef> { %s }' % eggSafeName(mat.yabee_name))
         return attributes
-    
+
     def collect_poly_normal(self, face, attributes):
         """ Add <Normal> to the polygon's attributes list.
-        
+
         @param face: face index.
         @param attributes: list of polygon's attributes.
-        
+
         @return: list of polygon's attributes.
         """
         no = self.obj_ref.matrix_world.to_euler().to_matrix() * face.normal
@@ -807,10 +807,10 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
     def collect_poly_bface(self, face, attributes):
         """ Add <BFace> to the polygon's attributes list.
-        
+
         @param face: face index.
         @param attributes: list of polygon's attributes.
-        
+
         @return: list of polygon's attributes.
         """
         if face.material_index < len(self.obj_ref.data.materials):
@@ -820,21 +820,21 @@ class EGGMeshObjectData(EGGBaseObjectData):
             if not self.obj_ref.data.materials[face.material_index].game_settings.use_backface_culling:
                 attributes.append('<BFace> { 1 }')
         return attributes
-        
+
     def collect_poly_vertexref(self, face, attributes):
         """ Add <VertexRef> to the polygon's attributes list.
-        
+
         @param face: face index.
         @param attributes: list of polygon's attributes.
-        
+
         @return: list of polygon's attributes.
         """
         vr = ' '.join(map(str,self.poly_vtx_ref[face.index]))
         attributes.append('<VertexRef> { %s <Ref> { %s }}' % (vr, eggSafeName(self.obj_ref.yabee_name)))
         return attributes
-    
+
     def collect_polygons(self):
-        """ Convert and collect polygons info 
+        """ Convert and collect polygons info
         """
         tref = self.collect_poly_tref
         mref = self.collect_poly_mref
@@ -859,9 +859,9 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
             polygons.append(poly)
         return polygons
-        
+
     def get_vtx_pool_str(self):
-        """ Return the vertex pool string in the EGG syntax. 
+        """ Return the vertex pool string in the EGG syntax.
         """
         vtx_pool = '<VertexPool> %s {\n' % eggSafeName(self.obj_ref.yabee_name)
         vtxs = ''.join(self.collect_vertices())
@@ -869,15 +869,15 @@ class EGGMeshObjectData(EGGBaseObjectData):
         vtx_pool += vtxs
         vtx_pool += '}\n'
         return vtx_pool
-        
+
     def get_polygons_str(self):
-        """ Return polygons string in the EGG syntax 
+        """ Return polygons string in the EGG syntax
         """
         polygons = '\n' + ''.join(self.collect_polygons())
         return polygons
-        
+
     def get_full_egg_str(self):
-        """ Return full mesh data representation in the EGG string syntax 
+        """ Return full mesh data representation in the EGG string syntax
         """
         return '\n'.join((self.get_transform_str(),
                         self.get_vtx_pool_str(),
@@ -885,18 +885,18 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
 
 #-----------------------------------------------------------------------
-#                           ACTOR OBJECT                                
+#                           ACTOR OBJECT
 #-----------------------------------------------------------------------
 
 class EGGActorObjectData(EGGMeshObjectData):
     """ Representation of the EGG animated object data
     """
-    
+
     def __init__(self, obj):
         EGGMeshObjectData.__init__(self,obj)
         self.joint_vtx_ref = self.pre_convert_joint_vtx_ref()
         #print(self.joint_vtx_ref)
-        
+
     def pre_convert_joint_vtx_ref(self):
         """ Collect and convert vertices, assigned to the bones
         """
@@ -915,10 +915,10 @@ class EGGActorObjectData(EGGMeshObjectData):
                     joint_vref[gname][self.obj_ref.yabee_name].append((idx, g.weight))
                 idx += 1
         return joint_vref
-        
+
     def get_joints_str(self):
-        """ Make  the EGGArmature object from the bones, pass the 
-        vertex referense to it, and return the EGG string representation 
+        """ Make  the EGGArmature object from the bones, pass the
+        vertex referense to it, and return the EGG string representation
         of the joints hierarchy.
         """
         j_str = ''
@@ -928,7 +928,7 @@ class EGGActorObjectData(EGGMeshObjectData):
                 ar.make_hierarchy_from_list(mod.object.data.bones)
                 j_str += ar.get_full_egg_str(self.joint_vtx_ref, mod.object, -1)
         return j_str
-        
+
     #def get_full_egg_str(self):
     #    """ Return string representation of the EGG animated object data.
     #    """
@@ -938,22 +938,22 @@ class EGGActorObjectData(EGGMeshObjectData):
 
 
 class EGGAnimJoint(Group):
-    """ Representation of the <Joint> animation data. Has the same 
+    """ Representation of the <Joint> animation data. Has the same
     hierarchy as the character's skeleton.
     """
     def make_hierarchy_from_list(self, obj_list):
         """ Old <Group> function
         -------------------------------
         This function make <Group> hierarchy from the list of
-        Blender's objects. Self.object is the top level of the created 
+        Blender's objects. Self.object is the top level of the created
         hierarchy. Usually in this case self.object == None
-        
+
         @param obj_list: tuple or lis of blender's objects.
         """
         for obj in obj_list:
-            if ((obj.parent == self.object) or 
-                ((self.object == None) and 
-                 (str(obj.parent) not in map(str,obj_list)) and 
+            if ((obj.parent == self.object) or
+                ((self.object == None) and
+                 (str(obj.parent) not in map(str,obj_list)) and
                  (str(obj) not in [str(ch.object) for ch in self.children]))):
                 try:
                     gr = self.__class__(obj)
@@ -963,7 +963,7 @@ class EGGAnimJoint(Group):
                 self.children.append(gr)
                 gr.make_hierarchy_from_list(obj_list)
         return []
-                
+
     def get_full_egg_str(self, anim_info, framerate, level = 0):
         """ Create and return the string representation of the <Joint>
         animation data, included all joints hierarchy.
@@ -979,31 +979,31 @@ class EGGAnimJoint(Group):
             egg_str += '%s    <V> {\n' % ('  ' * level)
             for i in range(len(bone_data['r'])):
                 egg_str += '%s      %s %s %s %s %s %s %s %s %s\n' % (
-                                                    '  ' * level, 
-                                                    STRF(1.0), 
-                                                    STRF(1.0), 
-                                                    STRF(1.0), 
-                                                    STRF(bone_data['p'][i]), 
-                                                    STRF(bone_data['r'][i]), 
+                                                    '  ' * level,
+                                                    STRF(1.0),
+                                                    STRF(1.0),
+                                                    STRF(1.0),
+                                                    STRF(bone_data['p'][i]),
+                                                    STRF(bone_data['r'][i]),
                                                     STRF(bone_data['h'][i]),
-                                                    STRF(bone_data['x'][i]), 
-                                                    STRF(bone_data['y'][i]), 
+                                                    STRF(bone_data['x'][i]),
+                                                    STRF(bone_data['y'][i]),
                                                     STRF(bone_data['z'][i]))
             egg_str += '%s    }\n' % ('  ' * level)
             egg_str += '%s  }\n' % ('  ' * level)
             for ch in self.children:
                 egg_str += ch.get_full_egg_str(anim_info, framerate, level + 1)
             egg_str += '%s}\n' % ('  ' * level)
-        else:        
+        else:
             for ch in self.children:
                 egg_str += ch.get_full_egg_str(anim_info, framerate, level + 1)
         return egg_str
 
 class AnimCollector():
-    """ Collect an armature and a shapekeys animation data and 
+    """ Collect an armature and a shapekeys animation data and
     convert it to the EGG string.
     """
-    
+
     def __init__(self, obj_list, start_f, stop_f, framerate, name, action=None):
         """ @param obj_list: list or tuple of the Blender's objects
         for wich needed to collect animation data.
@@ -1051,7 +1051,7 @@ class AnimCollector():
                             self.collect_arm_anims(obj)
     def collect_morph_anims(self, obj):
         """ Collect an animation data for the morph target (shapekeys).
-        
+
         @param obj: Blender's object for wich need to collect an animation data
         """
         keys = {}
@@ -1068,10 +1068,10 @@ class AnimCollector():
                     keys[key.name].append(key.value)
             bpy.context.scene.frame_current = current_f
         return keys
-    
+
     def collect_arm_anims(self, arm):
         """ Collect an animation data for the skeleton (Armature).
-        
+
         @param arm: Blender's Armature for wich need to collect an animation data
         """
         current_f = bpy.context.scene.frame_current
@@ -1100,11 +1100,11 @@ class AnimCollector():
                 anim_dict[bone.yabee_name]['z'].append(z)
         bpy.context.scene.frame_current = current_f
         return anim_dict
-    
+
     def get_morph_anim_str(self, obj_name):
         """ Create and return the EGG string of the morph animation for
         the given object.
-        
+
         @param obj_name: name of the Blender's object
         """
         morph_str = ''
@@ -1122,7 +1122,7 @@ class AnimCollector():
     def get_skeleton_anim_str(self, obj_name):
         """ Create and return the EGG string of the Armature animation for
         the given object.
-        
+
         @param obj_name: name of the Blender's object
         """
         skel_str = ''
@@ -1133,7 +1133,7 @@ class AnimCollector():
                 skel_str += '  %s\n' % line
             skel_str += '}\n'
         return skel_str
-              
+
     def get_full_egg_str(self):
         """ Create and return the full EGG string for the animation, wich
         has been setup in the object constructor (__init__)
@@ -1160,10 +1160,10 @@ class AnimCollector():
         return egg_str
 
 #-----------------------------------------------------------------------
-#                     SCENE MATERIALS & TEXTURES                        
+#                     SCENE MATERIALS & TEXTURES
 #-----------------------------------------------------------------------
 def get_used_materials(objects):
-    """ Collect Materials used in the selected object. 
+    """ Collect Materials used in the selected object.
     """
     m_list = []
     for obj in objects:
@@ -1190,7 +1190,7 @@ def get_egg_materials_str(object_names=None):
                     objects.append(obj)
     if not objects:
         return ''
-    
+
     mat_str = ''
     used_materials = get_used_materials(objects)
     for m_idx in used_materials:
@@ -1250,22 +1250,22 @@ def get_egg_materials_str(object_names=None):
         mat_str += '}\n\n'
     used_textures = {}
     if TEXTURE_PROCESSOR == 'SIMPLE':
-        st = SimpleTextures(objects, 
-                            EXPORT_UV_IMAGE_AS_TEXTURE, 
-                            COPY_TEX_FILES, 
+        st = SimpleTextures(objects,
+                            EXPORT_UV_IMAGE_AS_TEXTURE,
+                            COPY_TEX_FILES,
                             FILE_PATH, TEX_PATH)
         used_textures.update(st.get_used_textures())
     elif TEXTURE_PROCESSOR == 'RAW':
-        rt = RawTextures(objects, 
-                         EXPORT_UV_IMAGE_AS_TEXTURE, 
-                         COPY_TEX_FILES, 
+        rt = RawTextures(objects,
+                         EXPORT_UV_IMAGE_AS_TEXTURE,
+                         COPY_TEX_FILES,
                          FILE_PATH, TEX_PATH)
         used_textures.update(rt.get_used_textures())
-    
+
     if TEXTURE_PROCESSOR != 'RAW':
         tb = TextureBaker(objects, FILE_PATH, TEX_PATH)
         used_textures.update(tb.bake(BAKE_LAYERS))
-        
+
     for name, params in used_textures.items():
         mat_str += '<Texture> %s {\n' % eggSafeName(name)
         mat_str += '  "' + convertFileNameToPanda(params['path']) + '"\n'
@@ -1280,10 +1280,10 @@ def get_egg_materials_str(object_names=None):
             mat_str += '  }\n'
         mat_str += '}\n\n'
     return mat_str, used_materials, used_textures
-    
-    
+
+
 #-----------------------------------------------------------------------
-#                   Preparing & auxiliary functions                     
+#                   Preparing & auxiliary functions
 #-----------------------------------------------------------------------
 def hierarchy_to_list(obj, list, base_filter = None):
     if base_filter:
@@ -1402,7 +1402,7 @@ def generate_shadow_uvs():
     bpy.context.scene.update()
 
 #-----------------------------------------------------------------------
-#                           WRITE OUT                                   
+#                           WRITE OUT
 #-----------------------------------------------------------------------
 def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
               copy_tex, t_path, tbs, tex_processor, b_layers,
@@ -1434,7 +1434,7 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
         return s_acc % x
     STRF = str_f
     # Prepare copy of the scene.
-    # Sync objects names with custom property "yabee_name" 
+    # Sync objects names with custom property "yabee_name"
     # to be able to get basic object name in the copy of the scene.
     #selected_obj = [obj.name for obj in bpy.context.selected_objects if obj.type != 'ARMATURE']
     selected_obj = objects
@@ -1464,18 +1464,18 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
 
     old_data = {}
     for d in (bpy.data.materials, bpy.data.objects, bpy.data.textures,
-              bpy.data.armatures, bpy.data.actions, bpy.data.brushes, 
-              bpy.data.cameras, bpy.data.curves, bpy.data.groups, 
-              bpy.data.images, bpy.data.lamps, bpy.data.meshes, 
-              bpy.data.metaballs, bpy.data.movieclips, 
-              bpy.data.node_groups, bpy.data.particles, bpy.data.screens, 
-              bpy.data.scripts, bpy.data.shape_keys, bpy.data.sounds, 
-              bpy.data.speakers, bpy.data.texts, bpy.data.window_managers, 
+              bpy.data.armatures, bpy.data.actions, bpy.data.brushes,
+              bpy.data.cameras, bpy.data.curves, bpy.data.groups,
+              bpy.data.images, bpy.data.lamps, bpy.data.meshes,
+              bpy.data.metaballs, bpy.data.movieclips,
+              bpy.data.node_groups, bpy.data.particles, bpy.data.screens,
+              bpy.data.scripts, bpy.data.shape_keys, bpy.data.sounds,
+              bpy.data.speakers, bpy.data.texts, bpy.data.window_managers,
               bpy.data.worlds, bpy.data.grease_pencil):
         old_data[d] = d[:]
     bpy.ops.scene.new(type = 'FULL_COPY')
     try:
-        obj_list = [obj for obj in bpy.context.scene.objects 
+        obj_list = [obj for obj in bpy.context.scene.objects
                     if obj.yabee_name in selected_obj]
         if CALC_TBS == 'BLENDER':
             for obj in obj_list:
@@ -1503,7 +1503,7 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
         if BAKE_LAYERS and (BAKE_LAYERS['AO'][2] or BAKE_LAYERS['shadow'][2]):
             generate_shadow_uvs()
         gr = Group(None)
-        
+
         incl_arm = []
         for obj in bpy.context.scene.objects:
             if obj.yabee_name in selected_obj:
@@ -1520,7 +1520,7 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
         #print(incl_arm)
         obj_list += incl_arm
         print('Objects for export:', [obj.yabee_name for obj in obj_list])
-            
+
         errors += gr.make_hierarchy_from_list(obj_list)
         if not errors:
             #gr.print_hierarchy()
@@ -1597,11 +1597,11 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
         errors.append('ERR_UNEXPECTED')
         #print('\n'.join(format_tb(exc.__traceback__)))
         print_exc()
-    # Clearing the scene. 
-    # (!) Possible Incomplete. 
-    # Whenever we are deleted our copy of the scene, 
-    # Blender won't to delete other objects, created with the scene, so 
-    # we should do it by hand. I recommend to save the .blend file before 
+    # Clearing the scene.
+    # (!) Possible Incomplete.
+    # Whenever we are deleted our copy of the scene,
+    # Blender won't to delete other objects, created with the scene, so
+    # we should do it by hand. I recommend to save the .blend file before
     # exporting and reload it after.
     bpy.ops.scene.delete()
     for d in old_data:
@@ -1614,17 +1614,17 @@ def write_out(fname, anims, from_actions, uv_img_as_tex, sep_anim, a_only,
                     print ('WARNING: Can\'t delete', obj, 'from', d)
     return errors
 
-def write_out_test(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex, 
-              t_path, tbs, tex_processor, b_layers, 
+def write_out_test(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
+              t_path, tbs, tex_processor, b_layers,
               m_actor, apply_m, pview):
-    #return write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex, 
-    #          t_path, tbs, tex_processor, b_layers, 
+    #return write_out(fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
+    #          t_path, tbs, tex_processor, b_layers,
     #          m_actor, apply_m, pview)
     import profile
     import pstats
     wo = "write_out('%s', %s, %s, %s, %s, '%s', %s, '%s', '%s', %s, %s, %s, %s)" % \
-            (fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex, 
-              t_path, tbs, tex_processor, b_layers, 
+            (fname, anims, uv_img_as_tex, sep_anim, a_only, copy_tex,
+              t_path, tbs, tex_processor, b_layers,
               m_actor, apply_m, pview)
     wo = wo.replace('\\', '\\\\')
     profile.runctx(wo, globals(), {}, 'main_prof')

--- a/yabee_libs/texture_processor.py
+++ b/yabee_libs/texture_processor.py
@@ -15,14 +15,14 @@ BAKE_TYPES = {'diffuse': ('TEXTURE', 'MODULATE'),
 
 
 class SimpleTextures():
-    
+
     def __init__(self, obj_list, uv_img_as_texture, copy_tex, file_path, tex_path):
         self.obj_list = obj_list[:]
         self.uv_img_as_texture = uv_img_as_texture
         self.copy_tex = copy_tex
         self.file_path = file_path
         self.tex_path = tex_path
-        
+
     def is_slot_valid(self, tex):
         if ((tex) and (not tex.texture.use_nodes)):
             if tex.texture_coords in ('UV', 'GLOBAL', 'ORCO'):
@@ -30,30 +30,30 @@ class SimpleTextures():
                     return True
 
         return False
-        
+
     def get_valid_slots(self, slots):
         valid_slots = []
         for tex in slots:
             if(self.is_slot_valid(tex)):
                 valid_slots.append(tex)
-        
+
         return valid_slots
-        
+
     def get_alpha_slot(self, slots):
         for tex in slots:
-            if(tex.use_map_alpha): 
+            if(tex.use_map_alpha):
                 return tex
         return None
-        
+
     def get_active_uv_name(self, obj):
         auv = [uv for uv in obj.data.uv_textures if uv.active]
         if auv:
             return auv[0].name
         else:
             return ''
-        
+
     def get_used_textures(self):
-        """ Collect images from the UV images and Material texture slots 
+        """ Collect images from the UV images and Material texture slots
         tex_list structure:
             image_name: { 'scalars': [(name, val), (name, val), ...],
                           'path': 'path/to/texture',
@@ -198,7 +198,7 @@ class SimpleTextures():
 
                                     if(tuple(tex.offset) != (0.0, 0.0, 0.0)):
                                         transform.append(('Translate', tex.offset))
-                                    
+
                                     if(envtype == 'MODULATE'):
                                         if(alpha_tex and not alpha_map_assigned):
                                             alpha_map_assigned = True
@@ -207,7 +207,7 @@ class SimpleTextures():
                                                 alpha_path = save_image(alpha_tex.texture.image, self.file_path, self.tex_path)
                                             scalars.append(('alpha-file', '\"%s\"' % convertFileNameToPanda(alpha_path) ))
                                             scalars.append(('alpha-file-channel', '4'))
-                                            
+
                                             if(mat.game_settings.alpha_blend == 'CLIP'):
                                                 scalars.append(('alpha', 'BINARY'))
                                             elif(mat.game_settings.alpha_blend == 'ADD'):
@@ -216,8 +216,8 @@ class SimpleTextures():
                                 #    print('ERROR: can\'t get texture image on %s.' % tex.texture.name)
                     else:
                         use_uv_face_tex = True
-                    
-                    # use uv map image texture as face texture if appropriate flag 
+
+                    # use uv map image texture as face texture if appropriate flag
                     # checked, or material has not valid texture, or object has not material
                     if use_uv_face_tex:
                         for num, uv in enumerate(obj.data.uv_textures):
@@ -246,8 +246,8 @@ class SimpleTextures():
 
 
 class RawTextures(SimpleTextures):
-    
-    
+
+
     def is_slot_valid(self, tex):
         if tex and tex.texture and tex.texture.type == 'IMAGE' \
                and tex.texture.image \
@@ -255,7 +255,7 @@ class RawTextures(SimpleTextures):
             return True
 
         return False
-    
+
     '''
     def get_used_textures(self):
         tex_list = {}
@@ -276,9 +276,9 @@ class RawTextures(SimpleTextures):
                             t_path = tex.texture.image.filepath
                             if self.copy_tex:
                                 t_path = save_image(tex.texture.image, self.file_path, self.tex_path)
-                                
+
                             tex_list[tex.texture.yabee_name] = {'path': t_path,
-                                                                'scalars': scalars, 
+                                                                'scalars': scalars,
                                                                 'transform': transform }
                             if(tex.texture.use_mipmap):
                                 scalars.append(('minfilter', 'LINEAR_MIPMAP_LINEAR'))
@@ -327,13 +327,13 @@ class RawTextures(SimpleTextures):
 
                             if(tuple(tex.offset) != (0.0, 0.0, 0.0)):
                                 transform.append(('Translate', tex.offset))
-                                
+
                             if(tex.use_map_alpha and material.game_settings.alpha_blend == 'CLIP'):
                                 scalars.append(('alpha', 'BINARY'))
                 if not obj.data.materials[:]:
                     use_uv_face_tex = True
-                    
-                # use uv map image texture as face texture if appropriate flag 
+
+                # use uv map image texture as face texture if appropriate flag
                 # checked, or material has not valid texture, or object has not material
                 if use_uv_face_tex:
                     for num, uv in enumerate(obj.data.uv_textures):
@@ -356,27 +356,27 @@ class RawTextures(SimpleTextures):
                                         tex_list[tex_name]['scalars'].append(('alpha', 'BINARY'))
                                     if name:
                                         tex_list[tex_name]['scalars'].append(('uv-name', name))
-    
+
         return tex_list
         '''
 
 
 class TextureBaker():
-    
+
     def __init__(self, obj_list, file_path, tex_path):
         self.saved_objs = {}
         self.rendered_images = {}
         self.obj_list = obj_list[:]
         self.file_path = file_path
         self.tex_path = tex_path
-        
+
     def get_active_uv(self, obj):
         auv = [uv for uv in obj.data.uv_textures if uv.active]
         if auv:
             return auv[0]
         else:
             return None
-        
+
     def _save_obj_props(self, obj):
         props = {'uvs':[], 'textures':{}, 'active_uv': None}
         active_uv = self.get_active_uv(obj)
@@ -386,7 +386,7 @@ class TextureBaker():
                 #props['uvs'].append((uvd.use_image, uvd.image))
                 props['uvs'].append(uvd.image)
         self.saved_objs[obj.name] = props
-        
+
     def _restore_obj_props(self, obj):
         if obj.name in self.saved_objs.keys():
             props = self.saved_objs[obj.name]
@@ -419,33 +419,33 @@ class TextureBaker():
                     print('ERROR: %s have not active UV layer' % obj.name)
                     return None
         return assigned_data
-        
+
     def _clear_images(self):
         for iname in self.rendered_images.values():
             img = bpy.data.images[iname]
             img.user_clear()
             bpy.data.images.remove(img)
         self.rendred_images = []
-        
+
     def _save_rendered(self, spath):
         for oname, iname in self.rendered_images.items():
             img = bpy.data.images[iname]
             img.save_render(spath + iname + '.' + bpy.context.scene.render.file_format.lower())
-            
+
     def _save_images(self):
         paths = {}
         for oname, iname in self.rendered_images.items():
             img = bpy.data.images[iname]
             paths[iname] = save_image(img, self.file_path, self.tex_path)
         return paths
-        
+
     def _select(self, obj):
         obj.select = True
-        
+
     def _deselect(self, obj):
         obj.select = False
 
-               
+
     def bake(self, bake_layers):
         tex_list = {}
         for btype, params in bake_layers.items():
@@ -510,14 +510,14 @@ class TextureBaker():
                 else:
                     print('WARNING: unknown bake layer "%s"' % btype)
         return tex_list
-        
+
 
 
 
 
 if __name__ == '__main__':
     import os, sys
-    
+
     def convertFileNameToPanda(filename):
       """ (Get from Chicken) Converts Blender filenames to Panda 3D filenames.
       """
@@ -525,7 +525,7 @@ if __name__ == '__main__':
       if os.name == 'nt' and path.find(':') != -1:
         path = '/'+ path[0].lower() + path[2:]
       return path
-      
+
     def save_image(img, file_path, text_path):
         oldpath = bpy.path.abspath(img.filepath)
         old_dir, old_f = os.path.split(convertFileNameToPanda(oldpath))
@@ -557,8 +557,8 @@ if __name__ == '__main__':
                     img.save()
                     img.filepath == oldpath
         return rel_path
-        
-        
+
+
     tb = TextureBaker(bpy.context.selected_objects,'./exp_test/test.egg', './tex')
     print(tb.bake())
     st = SimpleTextures(bpy.context.selected_objects, False, False, './exp_test/test.egg', './tex')

--- a/yabee_libs/utils.py
+++ b/yabee_libs/utils.py
@@ -1,4 +1,4 @@
-""" 
+"""
     Part of the YABEE rev 12.1
 """
 import bpy, os, sys, shutil
@@ -15,7 +15,7 @@ def convertFileNameToPanda(filename):
 def save_image(img, file_path, text_path):
     if img.filepath:
         oldpath = bpy.path.abspath(img.filepath)
-        old_dir, old_f = os.path.split(convertFileNameToPanda(oldpath))       
+        old_dir, old_f = os.path.split(convertFileNameToPanda(oldpath))
         f_names = [s.lower() for s in old_f.split('.')]
         if not f_names[-1] in ('jpg', 'png', 'tga', 'tiff', 'dds', 'bmp') and img.is_dirty:
             old_f += ('.' + bpy.context.scene.render.image_settings.file_format.lower())
@@ -60,9 +60,9 @@ def get_active_uv(obj):
         return None
 
 def eggSafeName(s):
-    """ (Get from Chicken) Function that converts names into something 
-    suitable for the egg file format - simply puts " around names that 
-    contain spaces and prunes bad characters, replacing them with an 
+    """ (Get from Chicken) Function that converts names into something
+    suitable for the egg file format - simply puts " around names that
+    contain spaces and prunes bad characters, replacing them with an
     underscore.
     """
     s = str(s).replace('"','_') # Sure there are more bad characters, but this will do for now.


### PR DESCRIPTION
This pull request fixes all trailing whitespaces.

It also adds a new option called 'Export PBS' in the UI to export physically based materials using the new physically based material properties in Panda3D.

For that, it uses the panel of the <a href="https://github.com/tobspr/Panda3D-Bam-Exporter">BAM exporter</a>:
<img src="http://i.imgur.com/vMOI7wa.png">

It also exports various options into the emissive component, until Panda3D adds support for those (like normalmap strength)