### PR TITLE
Added support for "occluder" and "portal" tags

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -172,7 +172,7 @@ class Group:
                 if normalized in ('collide', 'objecttype'):
                     vals = ('  ' * level, prop.name, prop.value)
                     egg_str += '%s<%s> { %s }\n' % vals
-                elif normalized in ('collide-mask', 'from-collide-mask', 'into-collide-mask', 'bin', 'draw-order'):
+                elif normalized in ('collide-mask', 'from-collide-mask', 'into-collide-mask', 'bin', 'draw-order', 'occluder', "portal"):
                     vals = ('  ' * level, prop.name, prop.value)
                     egg_str += '%s<Scalar> %s { %s }\n' % vals
                 elif normalized == 'file' and self.object.type == 'EMPTY':


### PR DESCRIPTION
This allows an "occluder" or "portal" tag to be specified in Blender, and exported as expected by YABEE.