### PR TITLE
Export alpha channel in vertex colours, and additional vertex-colour layers

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -172,7 +172,7 @@ class Group:
                 if normalized in ('collide', 'objecttype'):
                     vals = ('  ' * level, prop.name, prop.value)
                     egg_str += '%s<%s> { %s }\n' % vals
-                elif normalized in ('collide-mask', 'from-collide-mask', 'into-collide-mask', 'bin', 'draw-order'):
+                elif normalized in ('collide-mask', 'from-collide-mask', 'into-collide-mask', 'bin', 'draw-order', 'occluder', "portal"):
                     vals = ('  ' * level, prop.name, prop.value)
                     egg_str += '%s<Scalar> %s { %s }\n' % vals
                 elif normalized == 'file' and self.object.type == 'EMPTY':


### PR DESCRIPTION
This commit includes two changes that I feel are somewhat similar, and somewhat connected.

The first change allows the user to export vertex colours with an alpha channel. Since Blender doesn't (as far as I'm aware) support vertex-colours with an alpha channel, this is done by adding a second layer of vertex-colours in Blender, with the "red" channel being interpreted as the "alpha" channel.

The second allows YABEE to export layers from the third onwards (as the second is used as described above) as "aux" layers.

(A quick note: I've used British English in naming the resultant shader-input. I imagine that it would make sense to change this to match the Panda's convention if the changes are accepted.)